### PR TITLE
Prevent from css broken

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -30,7 +30,7 @@ export default defineNuxtModule({
         if (typeof options.pluginOptions?.styles === 'string' && ['sass', 'expose'].includes(options.pluginOptions.styles)) {
             nuxt.options.css.unshift('vuetify/styles/main.sass')
         }
-        else if (options.pluginOptions?.styles === true) {
+        else if (options.pluginOptions?.styles === true || typeof options.pluginOptions?.styles === 'object') {
             nuxt.options.css.unshift('vuetify/styles')
         }
 
@@ -38,14 +38,12 @@ export default defineNuxtModule({
         nuxt.options.build.transpile.push(CONFIG_KEY)
 
         nuxt.hook('vite:extendConfig', (config) => {
-            config.optimizeDeps = defu(config.optimizeDeps, {
-                exclude: ['vuetify']
-            })
+            config.optimizeDeps = defu(config.optimizeDeps, { exclude: ['vuetify'] })
 
             // Vuetify plugin configuration
             config.plugins = [
                 ...(config.plugins || []),
-                vuetify(options.pluginOptions) as typeof config.plugins,
+                vuetify(options.pluginOptions),
             ]
 
             config.define = {
@@ -78,8 +76,7 @@ export default defineNuxtModule({
         })
 
         // Runtime
-        const runtime = resolve('./runtime/vuetify');
-        nuxt.options.alias['#vuetify'] = runtime;
+        nuxt.options.alias['#vuetify'] = resolve('./runtime/vuetify');
 
         // vuetify-specific composables
         addImports([

--- a/yarn.lock
+++ b/yarn.lock
@@ -2515,7 +2515,7 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-klona@^2.0.4, klona@^2.0.5:
+klona@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.5.tgz#d166574d90076395d9963aa7a928fabb8d76afbc"
   integrity sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ==
@@ -2842,11 +2842,6 @@ nanoid@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-4.0.0.tgz#6e144dee117609232c3f415c34b0e550e64999a5"
   integrity sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg==
-
-neo-async@^2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
-  integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
 nitropack@^1.0.0:
   version "1.0.0"
@@ -3727,14 +3722,6 @@ safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
-
-sass-loader@^13.2.0:
-  version "13.2.0"
-  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-13.2.0.tgz#80195050f58c9aac63b792fa52acb6f5e0f6bdc3"
-  integrity sha512-JWEp48djQA4nbZxmgC02/Wh0eroSUutulROUusYJO9P9zltRbNN80JCBHqRGzjd4cmZCa/r88xgfkjGD0TXsHg==
-  dependencies:
-    klona "^2.0.4"
-    neo-async "^2.6.2"
 
 sass@^1.56.2:
   version "1.56.2"


### PR DESCRIPTION
@Teranode , please check when you have time.

Issue:
- when we're using `styles` as object
```js
  pluginOptions: {
    autoImports: true, // default
    styles: { configFile: 'assets/sass/settings.scss' },
  },
```

We will got css broken, since it doesn't included the `vuetify/styles` with.