### PR TITLE
fix: compatibility with nuxt-vitest & vitest.config.mjs, fix #9

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -34,6 +34,7 @@ export default defineNuxtModule({
         // Transpile Vuetify
         nuxt.options.build.transpile.push(CONFIG_KEY)
 
+        // @ts-ignore: not appearing in typescript even though it is there.
         nuxt.hook('vite:configResolved', (config) => {
             config.optimizeDeps = defu(config.optimizeDeps, { exclude: ['vuetify'] })
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -34,7 +34,7 @@ export default defineNuxtModule({
         // Transpile Vuetify
         nuxt.options.build.transpile.push(CONFIG_KEY)
 
-        nuxt.hook('vite:extendConfig', (config) => {
+        nuxt.hook('vite:configResolved', (config) => {
             config.optimizeDeps = defu(config.optimizeDeps, { exclude: ['vuetify'] })
 
             // Vuetify plugin configuration


### PR DESCRIPTION
As per [Nuxt Hooks API Docs](https://nuxt.com/docs/api/advanced/hooks),
<html><body>
<!--StartFragment-->
<html><body>
<!--StartFragment-->

Hook | Arguments | Description
-- | -- | --
vite:extendConfig | viteInlineConfig, env | Allows to extend Vite default config.
vite:configResolved | viteInlineConfig, env | Allows to read the resolved Vite config.

<!--EndFragment-->
</body>
</html>

By modifying the resolved config instead of a default one, the plugin seems to be added in a correct order, avoiding the error in `vite-plugin-vuetify` dependency.

Please review if it's okay to apply all the changes.

Also please comment on the `'process.env.DEBUG': false,` override, at a first glance it seems this behavior may not be expected in the overridden config.