### PR TITLE
fix: use `lodash.template` directly to compile template

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,11 +28,13 @@
     },
     "dependencies": {
         "@nuxt/kit": "^3.2.2",
+        "lodash-es": "latest",
         "sass": "^1.58.3",
         "vite-plugin-vuetify": "^1.0.2",
         "vuetify": "^3.1.6"
     },
     "devDependencies": {
+        "@types/lodash-es": "latest",
         "@types/node": "^18.14.1",
         "nuxt": "^3.2.2",
         "unbuild": "latest"

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { template } from 'lodash-es'
 import type { ModuleOptions } from './types';
 import type { Nuxt } from '@nuxt/schema'
 import { name, version } from '../package.json';
@@ -67,7 +69,10 @@ export default defineNuxtModule({
         }
 
         addPluginTemplate({
-            src: resolve('./runtime/templates/plugin.mjs'),
+            getContents({ options }) {
+              const contents = readFileSync(resolve('./runtime/templates/plugin.mjs'), 'utf-8')
+              return template(contents)({ options })
+            },
             filename: 'vuetify.plugin.mjs',
             options: options.vuetifyOptions
         })

--- a/src/module.ts
+++ b/src/module.ts
@@ -70,8 +70,8 @@ export default defineNuxtModule({
 
         addPluginTemplate({
             getContents({ options }) {
-              const contents = readFileSync(resolve('./runtime/templates/plugin.mjs'), 'utf-8')
-              return template(contents)({ options })
+                const contents = readFileSync(resolve('./runtime/templates/plugin.mjs'), 'utf-8')
+                return template(contents)({ options })
             },
             filename: 'vuetify.plugin.mjs',
             options: options.vuetifyOptions


### PR DESCRIPTION
We are going to be removing support for [compiling templates from disk using `lodash.template`](https://github.com/nuxt/nuxt/issues/25332) in Nuxt v4. This is a PR to move lodash usage directly into the module to avoid breaking it on Nuxt 4.

It would also be possible to avoid using it entirely, which I would _strongly_ recommend, either:
* using a custom function to handle the replacement, such as in https://github.com/nuxt-modules/color-mode/pull/240
* or moving the string interpolation logic directly into `getContents`
